### PR TITLE
deactivate file cache oauth2client

### DIFF
--- a/class_gcalendar.py
+++ b/class_gcalendar.py
@@ -10,7 +10,7 @@ class CalendarApi:
 
         SCOPES = ["https://www.googleapis.com/auth/calendar"]
         gapi_creds = load_credentials_from_file(os.getenv("KEYJSONFILE"), SCOPES)[0]
-        self.service = build("calendar", "v3", credentials=gapi_creds)
+        self.service = build("calendar", "v3", credentials=gapi_creds, cache_discovery=False)
 
     def insert(self, body):
         result = self.service.events().insert(calendarId=self.calendarId, body=body).execute()


### PR DESCRIPTION
To remove the below log, the file cache option is disabled.
```
 2024-04-09 12:00:01,325 - INFO - file_cache is only supported with oauth2client<4.0.0
```
Ref: https://blog.g-gen.co.jp/entry/using-google-calendar-api-with-python