### PR TITLE
イベント一覧に過去イベントを通知しない変更

### DIFF
--- a/auto_task_notifier.py
+++ b/auto_task_notifier.py
@@ -202,6 +202,7 @@ def post_event_mgmt(event: dict, events: list, gcal: CalendarApi) -> None:
         line_text += f"{event['date']}({event['date'].strftime('%a')}): {event['title']}\n"
 
     # LINE 通知
+    # send_line_notify(line_text, os.getenv("LINE_USER_TOKEN_KEY"))
     send_line_notify(line_text, os.getenv("LINE_MGMT_TOKEN_KEY"))
     return None
 
@@ -260,7 +261,9 @@ def get_post_event_list(events: list) -> list:
             "date": datetime.date.fromisoformat(re.search(r"^\d{4}-\d{2}-\d{2}", event["start"]["dateTime"]).group()),
             "title": event["summary"],
         }
-        if post_event["date"] > upper_limit_date:
+        if post_event["date"] - datetime.date.today() <= datetime.timedelta(days=0):
+            continue
+        elif post_event["date"] > upper_limit_date:
             break
         post_events.append(post_event)
     return post_events

--- a/docs/docstring/class_gcalendar.md
+++ b/docs/docstring/class_gcalendar.md
@@ -12,7 +12,7 @@ Classes
     `delete(self, event)`
     :
 
-    `get(self, start_date: <module 'datetime' from '/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/datetime.py'> = datetime.datetime(2024, 8, 21, 1, 17, 43, 148242, tzinfo=datetime.timezone(datetime.timedelta(seconds=32400), 'JST')), prior_days: int = 30) ‑> list`
+    `get(self, start_date: <module 'datetime' from '/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/datetime.py'> = datetime.datetime(2024, 8, 21, 1, 18, 10, 23704, tzinfo=datetime.timezone(datetime.timedelta(seconds=32400), 'JST')), prior_days: int = 30) ‑> list`
     :   Google カレンダーの予定を取得するメソッド
         Args:
             start_date (datetime): 予定取得開始日。初期値は現在。

--- a/docs/docstring/class_gcalendar.md
+++ b/docs/docstring/class_gcalendar.md
@@ -12,7 +12,7 @@ Classes
     `delete(self, event)`
     :
 
-    `get(self, start_date: <module 'datetime' from '/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/datetime.py'> = datetime.datetime(2024, 8, 21, 1, 18, 10, 23704, tzinfo=datetime.timezone(datetime.timedelta(seconds=32400), 'JST')), prior_days: int = 30) ‑> list`
+    `get(self, start_date: <module 'datetime' from '/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/datetime.py'> = datetime.datetime(2024, 8, 21, 1, 18, 42, 426129, tzinfo=datetime.timezone(datetime.timedelta(seconds=32400), 'JST')), prior_days: int = 30) ‑> list`
     :   Google カレンダーの予定を取得するメソッド
         Args:
             start_date (datetime): 予定取得開始日。初期値は現在。

--- a/docs/docstring/class_gcalendar.md
+++ b/docs/docstring/class_gcalendar.md
@@ -12,7 +12,7 @@ Classes
     `delete(self, event)`
     :
 
-    `get(self, start_date: <module 'datetime' from '/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/datetime.py'> = datetime.datetime(2024, 8, 14, 15, 49, 1, 540464, tzinfo=datetime.timezone(datetime.timedelta(seconds=32400), 'JST')), prior_days: int = 30) ‑> list`
+    `get(self, start_date: <module 'datetime' from '/opt/hostedtoolcache/Python/3.11.9/x64/lib/python3.11/datetime.py'> = datetime.datetime(2024, 8, 21, 1, 17, 43, 148242, tzinfo=datetime.timezone(datetime.timedelta(seconds=32400), 'JST')), prior_days: int = 30) ‑> list`
     :   Google カレンダーの予定を取得するメソッド
         Args:
             start_date (datetime): 予定取得開始日。初期値は現在。


### PR DESCRIPTION
Fix #5 

```
[Monitoring] 今後の予定一覧です。
2024-09-01(日): xxx
2024-09-08(日): xxx
2024-10-05(土): xxx
2024-10-12(土): xxx
```