### PR TITLE
docstringが変化し続けてActionsがループするバグがあったため修正

### DIFF
--- a/.github/workflows/linter-docstrings.yaml
+++ b/.github/workflows/linter-docstrings.yaml
@@ -30,6 +30,7 @@ jobs:
           pip install -r requirements.txt
           rm -rf docs/docstring
           pdoc --force -o docs/docstring *.py
+          python module/fix_docstring.py
       - name: Commit files
         continue-on-error: true
         run: |

--- a/docs/docstring/class_gcalendar.md
+++ b/docs/docstring/class_gcalendar.md
@@ -12,7 +12,7 @@ Classes
     `delete(self, event)`
     :
 
-    `get(self, start_date: <module 'datetime' from '/opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/datetime.py'> = datetime.datetime(2024, 11, 5, 10, 15, 8, 945637, tzinfo=datetime.timezone(datetime.timedelta(seconds=32400), 'JST')), prior_days: int = 30) ‑> list`
+    `get(self, start_date: datetime = datetime.datetime.now(datetime.timezone(datetime.timedelta(hours=+9), 'JST')), prior_days: int = 30) ‑> list`
     :   Google カレンダーの予定を取得するメソッド
         Args:
             start_date (datetime): 予定取得開始日。初期値は現在。

--- a/module/fix_docstring.py
+++ b/module/fix_docstring.py
@@ -1,0 +1,44 @@
+import logging
+from pathlib import Path
+import re
+
+# Logging
+logging.basicConfig(level=logging.INFO, format=" %(asctime)s - %(levelname)s - %(message)s")
+logging.info("#=== Start program ===#")
+
+
+def fix_docstring() -> None:
+    """
+    関数に変数が含まれるとdocstring生成の際に無限ループとなる場合があるため、修正する関数
+    * class_gcalendar.pyのget関数の引数にdatetime.datetime.now()があり、無限ループを引き起こしている。
+    docstring出力後に修正する前提の関数とする
+    """
+    # class_gcalendar.md の修正
+    target_file = Path('docs/docstring/class_gcalendar.md')
+    if not target_file.is_file():
+        logging.info(f"File not found: {target_file}")
+        return
+    target_sentence_ptrn = r"start_date:.*, prior_days"
+    replace_sentence = "start_date: datetime = datetime.datetime.now(datetime.timezone(datetime.timedelta(hours=+9), 'JST')), prior_days"
+    change_string(target_sentence_ptrn, replace_sentence, target_file)
+
+
+def change_string(pattern: str, replace_str: str, file_path: Path) -> None:
+    """
+    Args:
+        pattern (str): input pattern. raw string is preferable.
+        replace_str (str): string to be.
+        file_path (Path): target file path.
+    """
+    with open(file_path, "r", encoding="utf-8") as f:
+        docfile = f.read()
+    new_docfile = re.sub(pattern, replace_str, docfile)
+    with open(file_path, "w", encoding="utf-8") as f:
+        f.write(new_docfile)
+        logging.info(f"File is replaced: {file_path}")
+
+# Main ---
+
+
+if __name__ == "__main__":
+    fix_docstring()

--- a/module/fix_docstring.py
+++ b/module/fix_docstring.py
@@ -14,14 +14,15 @@ def fix_docstring() -> None:
     docstring出力後に修正する前提の関数とする
     """
     # class_gcalendar.md の修正
-    target_file = Path('docs/docstring/class_gcalendar.md')
+    target_file = Path("docs/docstring/class_gcalendar.md")
     if not target_file.is_file():
         logging.info(f"File not found: {target_file}")
         return
     target_sentence_ptrn = r"start_date:.*, prior_days"
-    replace_sentence = \
-        "start_date: datetime = datetime.datetime.now(datetime.timezone(datetime.timedelta(hours=+9), 'JST')), "\
+    replace_sentence = (
+        "start_date: datetime = datetime.datetime.now(datetime.timezone(datetime.timedelta(hours=+9), 'JST')), "
         + "prior_days"
+    )
     change_string(target_sentence_ptrn, replace_sentence, target_file)
 
 
@@ -38,6 +39,7 @@ def change_string(pattern: str, replace_str: str, file_path: Path) -> None:
     with open(file_path, "w", encoding="utf-8") as f:
         f.write(new_docfile)
         logging.info(f"File is replaced: {file_path}")
+
 
 # Main ---
 

--- a/module/fix_docstring.py
+++ b/module/fix_docstring.py
@@ -19,7 +19,9 @@ def fix_docstring() -> None:
         logging.info(f"File not found: {target_file}")
         return
     target_sentence_ptrn = r"start_date:.*, prior_days"
-    replace_sentence = "start_date: datetime = datetime.datetime.now(datetime.timezone(datetime.timedelta(hours=+9), 'JST')), prior_days"
+    replace_sentence = \
+        "start_date: datetime = datetime.datetime.now(datetime.timezone(datetime.timedelta(hours=+9), 'JST')), "\
+        + "prior_days"
     change_string(target_sentence_ptrn, replace_sentence, target_file)
 
 


### PR DESCRIPTION
```python
def get(
    self,
    start_date: datetime = datetime.datetime.now(datetime.timezone(datetime.timedelta(hours=+9), "JST")),
    prior_days: int = 30,
) -> list:
```

引数にdatetimeの関数が入っているのが良くない。

```python
`get(self, start_date: <module 'datetime' from '/opt/hostedtoolcache/Python/3.11.10/x64/lib/python3.11/datetime.py'> = datetime.datetime(2024, 11, 5, 10, 14, 36, 583418, tzinfo=datetime.timezone(datetime.timedelta(seconds=32400), 'JST')), prior_days: int = 30) ‑> list`
```

実行結果が返ってしまっているので、関数のまま文字列を書きたい。