### PR TITLE
migrate to LINE Messaging API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ LINE_USER_TOKEN_KEY="Not available"
 LINE_MGMT_TOKEN_KEY="input your LINE token key."
 LINE_DEMO_TOKEN_KEY="input your LINE token key for DEMO mode."
 LUXY_BDG_ACC_BOOK="input the URL of the account book of the group."
+LINE_MESSAGE_API_GROUP_ID_USER="Not available"
+LINE_MESSAGE_API_GROUP_ID_MGMT="input your LINE Group ID."
+LINE_MESSAGE_API_GROUP_ID_DEMO="input your LINE Group ID for DEMO mode."
 
 # Choseisan
 CHOSEISAN_MAIL="input your ID."

--- a/auto_task_notifier.py
+++ b/auto_task_notifier.py
@@ -10,7 +10,7 @@ import re
 import locale
 from class_gcalendar import CalendarApi, EventNotFoundException
 from make_choseisan import make_choseisan
-from common_tools import detect_event_type, send_line_notify
+from common_tools import detect_event_type, send_line_masageapi
 
 
 # Parameters ------------------
@@ -51,14 +51,14 @@ def auto_task_notifier_main() -> None:
         events = get_events_googlecal(gcal)
     except Exception as e:
         logging.error(f"### Error: {e} ###")
-        send_error_to_line(os.getenv("LINE_MGMT_TOKEN_KEY"))
+        send_error_to_line(os.getenv("LINE_MESSAGE_API_GROUP_ID_MGMT"))
 
     # 何の対応が必要か判定
     try:
         goto_each_task(gcal, events)
     except Exception as e:
         logging.error(f"### Error: {e} ###")
-        send_error_to_line(os.getenv("LINE_MGMT_TOKEN_KEY"))
+        send_error_to_line(os.getenv("LINE_MESSAGE_API_GROUP_ID_MGMT"))
 
     logging.info("#=== Program Finished ===#")
 
@@ -126,7 +126,7 @@ def one_week_pre_mgmt(event: dict) -> None:
     if "TRPG" in event["summary"]:
         line_text += "各卓のマスターに準備状況を確認してください。\n"
     # LINE 通知
-    send_line_notify(line_text, os.getenv("LINE_MGMT_TOKEN_KEY"))
+    send_line_masageapi(line_text, os.getenv("LINE_MESSAGE_API_GROUP_ID_MGMT"))
     return None
 
 
@@ -150,7 +150,7 @@ def pre_event_mgmt(event: dict) -> None:
     if "TRPG" in event["summary"]:
         line_text += "次々回の卓内容も考えて宣伝できるようにしておきましょう。\n"
     # LINE 通知
-    send_line_notify(line_text, os.getenv("LINE_MGMT_TOKEN_KEY"))
+    send_line_masageapi(line_text, os.getenv("LINE_MESSAGE_API_GROUP_ID_MGMT"))
     return None
 
 
@@ -175,7 +175,7 @@ def post_event_mgmt(event: dict, events: list, gcal: CalendarApi) -> None:
     line_text += os.getenv("LUXY_BDG_ACC_BOOK") + "\n"
     line_text += "今回の参加者はこちらです。\n"
     line_text += detect_remove_a_tag(event["description"]) + "\n"
-    send_line_notify(line_text, os.getenv("LINE_MGMT_TOKEN_KEY"))
+    send_line_masageapi(line_text, os.getenv("LINE_MESSAGE_API_GROUP_ID_MGMT"))
 
     # 次回の案内
     next_event = get_next_event(event, events)
@@ -193,7 +193,7 @@ def post_event_mgmt(event: dict, events: list, gcal: CalendarApi) -> None:
         line_text += choseisan_url
 
     # LINE 通知
-    send_line_notify(line_text, os.getenv("LINE_MGMT_TOKEN_KEY"))
+    send_line_masageapi(line_text, os.getenv("LINE_MESSAGE_API_GROUP_ID_MGMT"))
 
     # 今後の予定の案内
     post_event_list = get_post_event_list(events)
@@ -203,7 +203,7 @@ def post_event_mgmt(event: dict, events: list, gcal: CalendarApi) -> None:
 
     # LINE 通知
     # send_line_notify(line_text, os.getenv("LINE_USER_TOKEN_KEY"))
-    send_line_notify(line_text, os.getenv("LINE_MGMT_TOKEN_KEY"))
+    send_line_masageapi(line_text, os.getenv("LINE_MESSAGE_API_GROUP_ID_MGMT"))
     return None
 
 
@@ -269,9 +269,9 @@ def get_post_event_list(events: list) -> list:
     return post_events
 
 
-def send_error_to_line(line_notify_token: str) -> None:
+def send_error_to_line(line_group_id: str) -> None:
     message = "何らかのエラーが発生したようです。ログを確認してください。"
-    send_line_notify(message, line_notify_token)
+    send_line_masageapi(message, line_group_id)
 
 
 # Main ---

--- a/common_tools.py
+++ b/common_tools.py
@@ -28,22 +28,22 @@ def send_line_masageapi(notification_message: str, line_group_id: str) -> None:
         notification_message (str): 送信メッセージ
         line_notify_token (str): 送信宛先LINEトークン。DEMOモードの場合、強制上書き。
     """
-    line_token = os.getenv('LINE_CHANNEL_ACCESS_TOKEN')
+    line_token = os.getenv("LINE_CHANNEL_ACCESS_TOKEN")
     if os.getenv("DEMO_MODE") == "1":
         # DEMOモードの場合は強制的にデモ用の宛先へ変更
         line_group_id = os.getenv("LINE_MESSAGE_API_GROUP_ID_DEMO")
     # line_group_id = os.getenv('LINE_MESSAGE_API_GROUP_ID')
-    line_api_url = 'https://api.line.me/v2/bot/message/push'
+    line_api_url = "https://api.line.me/v2/bot/message/push"
     headers = {
-        'Content-Type': 'application/json',
-        'Authorization': f'Bearer {line_token}',
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {line_token}",
     }
     data = {
-        'to': line_group_id,
-        'messages': [
+        "to": line_group_id,
+        "messages": [
             {
-                'type': 'text',
-                'text': notification_message,
+                "type": "text",
+                "text": notification_message,
             },
         ],
     }

--- a/common_tools.py
+++ b/common_tools.py
@@ -1,6 +1,7 @@
 import os
 import requests
 from class_str_enum import EventIdStrEnum
+import json
 
 
 def detect_event_type(event: dict) -> EventIdStrEnum:
@@ -20,17 +21,30 @@ def detect_event_type(event: dict) -> EventIdStrEnum:
     return event_type
 
 
-def send_line_notify(notification_message: str, line_notify_token: str) -> None:
+def send_line_masageapi(notification_message: str, line_group_id: str) -> None:
     """
     LINEに通知する
     Args:
         notification_message (str): 送信メッセージ
         line_notify_token (str): 送信宛先LINEトークン。DEMOモードの場合、強制上書き。
     """
+    line_token = os.getenv('LINE_CHANNEL_ACCESS_TOKEN')
     if os.getenv("DEMO_MODE") == "1":
         # DEMOモードの場合は強制的にデモ用の宛先へ変更
-        line_notify_token = os.getenv("LINE_DEMO_TOKEN_KEY")
-    line_notify_api = "https://notify-api.line.me/api/notify"
-    headers = {"Authorization": f"Bearer {line_notify_token}"}
-    data = {"message": notification_message}
-    requests.post(line_notify_api, headers=headers, data=data)
+        line_group_id = os.getenv("LINE_MESSAGE_API_GROUP_ID_DEMO")
+    # line_group_id = os.getenv('LINE_MESSAGE_API_GROUP_ID')
+    line_api_url = 'https://api.line.me/v2/bot/message/push'
+    headers = {
+        'Content-Type': 'application/json',
+        'Authorization': f'Bearer {line_token}',
+    }
+    data = {
+        'to': line_group_id,
+        'messages': [
+            {
+                'type': 'text',
+                'text': notification_message,
+            },
+        ],
+    }
+    requests.post(line_api_url, headers=headers, data=json.dumps(data))

--- a/docs/docstring/auto_task_notifier.md
+++ b/docs/docstring/auto_task_notifier.md
@@ -86,5 +86,5 @@ Functions
     Returns:
         None
 
-`send_error_to_line(line_notify_token: str) ‑> None`
+`send_error_to_line(line_group_id: str) ‑> None`
 :

--- a/docs/docstring/common_tools.md
+++ b/docs/docstring/common_tools.md
@@ -11,7 +11,7 @@ Functions
     Returns:
         event_type (EventIdStrEnum): イベント種別
 
-`send_line_notify(notification_message: str, line_notify_token: str) ‑> None`
+`send_line_masageapi(notification_message: str, line_group_id: str) ‑> None`
 :   LINEに通知する
     Args:
         notification_message (str): 送信メッセージ


### PR DESCRIPTION
[LINE Notify提供終了のお知らせ](https://notify-bot.line.me/closing-announce)
のため、LINE通知方法を変更する必要がある。
LINE Messaging APIという機能があるため、活用する。
