### PR TITLE
調整さんを日付指定で作成する機能を追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ CALENDAR_ID="input your google account."
 
 # LINE
 LUXY_BDG_ACC_BOOK="input the URL of the account book of the group."
+LINE_CHANNEL_ACCESS_TOKEN="input your LINE channel access token."
 LINE_MESSAGE_API_GROUP_ID_USER="Not available"
 LINE_MESSAGE_API_GROUP_ID_MGMT="input your LINE Group ID."
 LINE_MESSAGE_API_GROUP_ID_DEMO="input your LINE Group ID for DEMO mode."

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ Google カレンダーから予定を取得し、調整さんを作成して、L
 
 - Google カレンダーから予定情報を取得
 - 調整さんのイベント自動生成
-- 生成したイベント情報をLINEへ通知
+- 生成したイベント情報を LINE Messaging API で通知
 - テンプレートによる通知コメントのカスタマイズ
+- 指定日のイベントに対する調整さんの手動作成
 
 ## セットアップ
 
@@ -16,7 +17,7 @@ Google カレンダーから予定を取得し、調整さんを作成して、L
 
 - Python 3.11 以上
 - Google カレンダーAPI利用のための認証情報
-- LINE Notifyのアクセストークン
+- LINE Messaging API のチャネルアクセストークン
 
 ### 2. リポジトリのクローン
 
@@ -36,19 +37,29 @@ pip install -r requirements.txt
 `.env.example` を参考に `.env` を作成し、各種APIキーやトークンを設定してください。
 
 ```
-GOOGLE_API_KEY=your_google_api_key
-LINE_NOTIFY_TOKEN=your_line_notify_token
+...
+CALENDAR_ID=your_google_calendar_id
+LINE_CHANNEL_ACCESS_TOKEN=your_line_channel_access_token
 ...
 ```
 
 ## 使い方
 
+### 自動通知（通常実行）
+
 ```sh
 python auto_task_notifier.py
 ```
 
-- 日程調整イベントの自動作成・通知が実行されます。
-- 詳細な実行方法やパラメータについては各Pythonファイル内のコメントも参照してください。
+Google カレンダーの予定を走査し、イベントの1週間前・前日・翌日に応じた LINE 通知を自動で送信します。
+
+### 指定日の調整さん作成
+
+```sh
+python auto_task_notifier.py --create-choseisan YYYY-MM-DD
+```
+
+指定日に登録されている Google カレンダーのイベントに対して調整さんを作成し、URL をカレンダーの説明欄に登録します。LINE 通知は行いません。既に説明が登録されているイベントはスキップされます。
 
 ## ファイル構成
 
@@ -62,9 +73,9 @@ python auto_task_notifier.py
 
 ## Google/LINE連携の設定
 
-- GoogleカレンダーAPIの認証情報取得や、LINE Notifyのトークン発行方法は公式ドキュメント等をご参照ください。
+- GoogleカレンダーAPIの認証情報取得や、LINE Messaging API のチャネルアクセストークン発行方法は公式ドキュメント等をご参照ください。
   - [Google Calendar API](https://developers.google.com/calendar)
-  - [LINE Notify](https://notify-bot.line.me/ja/)
+  - [LINE Messaging API](https://developers.line.biz/ja/docs/messaging-api/)
 
 ## ライセンス
 

--- a/auto_task_notifier.py
+++ b/auto_task_notifier.py
@@ -2,6 +2,7 @@
 This is main function to manage this repogitory.
 """
 
+import argparse
 import logging
 from dotenv import load_dotenv
 import datetime
@@ -147,9 +148,7 @@ class EventNotifier:
         if next_ev.description is not None:
             text += next_ev.clean_description
         else:
-            choseisan_url = make_choseisan(next_ev.raw)
-            next_ev.description = choseisan_url
-            self.gcal.update(next_ev.raw)
+            choseisan_url = create_choseisan_for_event(self.gcal, next_ev)
             text += choseisan_url
         self.notify(text)
 
@@ -177,6 +176,15 @@ class EventNotifier:
 
 
 # Functions ------------------
+
+
+def create_choseisan_for_event(gcal: CalendarApi, event: Event) -> str:
+    """指定イベントの調整さんを作成し、Google カレンダーに URL を登録する"""
+    choseisan_url = make_choseisan(event.raw)
+    event.description = choseisan_url
+    gcal.update(event.raw)
+    logging.info(f"調整さんを作成しました: {event.summary} ({event.date}) -> {choseisan_url}")
+    return choseisan_url
 
 
 def detect_remove_a_tag(description: str) -> str:
@@ -244,5 +252,65 @@ def auto_task_notifier_main() -> None:
     logging.info("#=== Program Finished ===#")
 
 
+def create_choseisan_by_date_main(target_date_str: str) -> None:
+    """指定日のイベントに対して調整さんを作成し、Google カレンダーに URL を登録する"""
+    logging.basicConfig(level=logging.INFO, format=" %(asctime)s - %(levelname)s - %(message)s")
+    logging.info("#=== Start create_choseisan_by_date ===#")
+
+    load_dotenv()
+
+    try:
+        target_date = datetime.date.fromisoformat(target_date_str)
+    except ValueError:
+        logging.error(f"日付の形式が不正です: {target_date_str} (YYYY-MM-DD で指定してください)")
+        return
+
+    try:
+        gcal = CalendarApi()
+        target_datetime = datetime.datetime(target_date.year, target_date.month, target_date.day, tzinfo=JST)
+        raw_events = gcal.get(start_date=target_datetime, prior_days=0)
+        events = [Event(e) for e in raw_events]
+    except EventNotFoundException:
+        logging.error(f"{target_date} にイベントが見つかりませんでした。")
+        return
+    except Exception as e:
+        logging.error(f"### Error: {e} ###")
+        return
+
+    # 指定日のイベントを検索
+    matched = []
+    for ev in events:
+        try:
+            if ev.date == target_date:
+                matched.append(ev)
+        except ValueError as e:
+            logging.warning(f"イベントの日付取得をスキップしました: {e}")
+    if not matched:
+        logging.error(f"{target_date} にイベントが見つかりませんでした。")
+        return
+
+    for event in matched:
+        if event.description is not None:
+            logging.info(f"スキップ: {event.summary} ({event.date}) は既に説明が登録されています。")
+            continue
+        try:
+            create_choseisan_for_event(gcal, event)
+        except Exception as e:
+            logging.error(f"調整さんの作成に失敗しました: {event.summary} ({event.date}) - {e}")
+
+    logging.info("#=== Program Finished ===#")
+
+
 if __name__ == "__main__":
-    auto_task_notifier_main()
+    parser = argparse.ArgumentParser(description="Auto Task Notifier")
+    parser.add_argument(
+        "--create-choseisan",
+        metavar="YYYY-MM-DD",
+        help="指定日のイベントに対して調整さんを作成する",
+    )
+    args = parser.parse_args()
+
+    if args.create_choseisan:
+        create_choseisan_by_date_main(args.create_choseisan)
+    else:
+        auto_task_notifier_main()

--- a/docs/docstring/auto_task_notifier.md
+++ b/docs/docstring/auto_task_notifier.md
@@ -8,6 +8,12 @@ Functions
 `auto_task_notifier_main() ‑> None`
 :   スケジュールから自動的にタスクを通知するプログラム
 
+`create_choseisan_by_date_main(target_date_str: str) ‑> None`
+:   指定日のイベントに対して調整さんを作成し、Google カレンダーに URL を登録する
+
+`create_choseisan_for_event(gcal: class_gcalendar.CalendarApi, event: auto_task_notifier.Event) ‑> str`
+:   指定イベントの調整さんを作成し、Google カレンダーに URL を登録する
+
 `detect_remove_a_tag(description: str) ‑> str`
 :   detect & remove HTML a tag.
     Args:

--- a/make_choseisan.py
+++ b/make_choseisan.py
@@ -66,7 +66,13 @@ def make_choseisan(event: dict) -> str:
     Returns:
         choseisan_url (str): 作成された調整さんのURL
     """
-    event_date = datetime.date.fromisoformat(re.search(r"^\d{4}-\d{2}-\d{2}", event["start"]["dateTime"]).group())
+    start_value = event["start"].get("dateTime") or event["start"].get("date")
+    if start_value is None:
+        raise ValueError("Event start is missing both 'dateTime' and 'date'")
+    match = re.search(r"^\d{4}-\d{2}-\d{2}", start_value)
+    if match is None:
+        raise ValueError(f"Event start value is not a valid ISO date: {start_value!r}")
+    event_date = datetime.date.fromisoformat(match.group())
     event_date_str = event_date.strftime("%Y/%m/%d")
     choseisan_title = f"{event['summary']} - {event_date_str}"
     event_type = detect_event_type(event)


### PR DESCRIPTION
- Extract create_choseisan_for_event() as shared logic used by both the existing post-event notification flow and the new CLI option.
- The new mode finds events on the given date, creates choseisan URLs, and registers them to Google Calendar without sending LINE notifications.