### PR TITLE
調整さん作成オプションの日付フォーマットを複数の形式で対応できるように変更

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,15 @@ Google カレンダーの予定を走査し、イベントの1週間前・前日
 ### 指定日の調整さん作成
 
 ```sh
-python auto_task_notifier.py --create-choseisan YYYY-MM-DD
+python auto_task_notifier.py --create-choseisan DATE
 ```
+
+日付は以下の形式に対応しています。
+
+- `YYYY-MM-DD` (例: `2026-04-19`)
+- `YYYYMMDD` (例: `20260419`)
+- `YYYY/MM/DD` (例: `2026/04/19`)
+- `YYYY.MM.DD` (例: `2026.04.19`)
 
 指定日に登録されている Google カレンダーのイベントに対して調整さんを作成し、URL をカレンダーの説明欄に登録します。LINE 通知は行いません。既に説明が登録されているイベントはスキップされます。
 

--- a/auto_task_notifier.py
+++ b/auto_task_notifier.py
@@ -16,6 +16,7 @@ from common_tools import detect_event_type, send_line_masageapi
 
 # Parameters ------------------
 JST = datetime.timezone(datetime.timedelta(hours=+9), "JST")
+DATE_FORMATS_HINT = "YYYY-MM-DD, YYYYMMDD, YYYY/MM/DD, YYYY.MM.DD"
 # localeモジュールで曜日を日本語表示にする
 try:
     if os.name == "nt":  # Windows
@@ -260,9 +261,15 @@ def create_choseisan_by_date_main(target_date_str: str) -> None:
     load_dotenv()
 
     try:
-        target_date = datetime.date.fromisoformat(target_date_str)
+        stripped = target_date_str.strip()
+        normalized = re.sub(r"[/.]", "-", stripped)
+        if re.fullmatch(r"\d{8}", normalized):
+            normalized = f"{normalized[:4]}-{normalized[4:6]}-{normalized[6:]}"
+        target_date = datetime.date.fromisoformat(normalized)
     except ValueError:
-        logging.error(f"日付の形式が不正です: {target_date_str} (YYYY-MM-DD で指定してください)")
+        logging.error(
+            f"日付の形式が不正です: {target_date_str} ({DATE_FORMATS_HINT} で指定してください)"
+        )
         return
 
     try:
@@ -305,8 +312,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Auto Task Notifier")
     parser.add_argument(
         "--create-choseisan",
-        metavar="YYYY-MM-DD",
-        help="指定日のイベントに対して調整さんを作成する",
+        metavar="DATE",
+        help=f"指定日のイベントに対して調整さんを作成する ({DATE_FORMATS_HINT})",
     )
     args = parser.parse_args()
 

--- a/auto_task_notifier.py
+++ b/auto_task_notifier.py
@@ -267,9 +267,7 @@ def create_choseisan_by_date_main(target_date_str: str) -> None:
             normalized = f"{normalized[:4]}-{normalized[4:6]}-{normalized[6:]}"
         target_date = datetime.date.fromisoformat(normalized)
     except ValueError:
-        logging.error(
-            f"日付の形式が不正です: {target_date_str} ({DATE_FORMATS_HINT} で指定してください)"
-        )
+        logging.error(f"日付の形式が不正です: {target_date_str} ({DATE_FORMATS_HINT} で指定してください)")
         return
 
     try:


### PR DESCRIPTION
  Accept YYYYMMDD, YYYY/MM/DD, and YYYY.MM.DD in addition to YYYY-MM-DD.

This pull request improves the flexibility of date input handling in the `create_choseisan_by_date_main` function, allowing users to specify dates in multiple common formats. The changes also update the help text and error messages to reflect the expanded accepted formats.

**Enhancements to date input handling:**

* The function now normalizes the input date string, allowing formats such as `YYYY-MM-DD`, `YYYYMMDD`, `YYYY/MM/DD`, and `YYYY.MM.DD` to be accepted and correctly parsed.

**User interface improvements:**

* Updated the command-line argument help text and error messages to inform users that multiple date formats are supported. [[1]](diffhunk://#diff-eb12e95343241272ac148dc7da7b853d0f0d936a3c62d2cddc0291147fe62c17L263-R268) [[2]](diffhunk://#diff-eb12e95343241272ac148dc7da7b853d0f0d936a3c62d2cddc0291147fe62c17L308-R312)